### PR TITLE
Add pubDate to RSS feed

### DIFF
--- a/rss.xml
+++ b/rss.xml
@@ -9,886 +9,1063 @@
     <title>On Stateless Societies</title>
     <link>http://250bpm.com/blog:177</link>
     <description>On Stateless Societies</description>
+    <pubDate>Mon, 27 Dec 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Technocratic Plimsoll Line</title>
     <link>http://250bpm.com/blog:176</link>
     <description>Technocratic Plimsoll Line</description>
+    <pubDate>Sat, 15 May 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Chesterton&#x27;s Fence</title>
     <link>http://250bpm.com/blog:175</link>
     <description>On Chesterton&#x27;s Fence</description>
+    <pubDate>Thu, 29 Apr 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Jean Monnet: The Guerilla Bureaucrat  </title>
     <link>http://250bpm.com/blog:174</link>
     <description>Jean Monnet: The Guerilla Bureaucrat  </description>
+    <pubDate>Sat, 20 Mar 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Teaching to Compromise</title>
     <link>http://250bpm.com/blog:173</link>
     <description>Teaching to Compromise</description>
+    <pubDate>Sun, 07 Mar 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On the Nature of Reputation</title>
     <link>http://250bpm.com/blog:172</link>
     <description>On the Nature of Reputation</description>
+    <pubDate>Sat, 20 Feb 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Democracy, Bureaucracy, Central Banking</title>
     <link>http://250bpm.com/blog:171</link>
     <description>Democracy, Bureaucracy, Central Banking</description>
+    <pubDate>Sun, 07 Feb 2021 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Story of the Reichstag</title>
     <link>http://250bpm.com/blog:170</link>
     <description>The Story of the Reichstag</description>
+    <pubDate>Sun, 05 Feb 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Musical moment in d minor</title>
     <link>http://250bpm.com/blog:169</link>
     <description>Musical moment in d minor</description>
+    <pubDate>Sun, 01 Nov 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Political Lottery in Switzerland</title>
     <link>http://250bpm.com/blog:168</link>
     <description>Political Lottery in Switzerland</description>
+    <pubDate>Thu, 08 Oct 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Simplest Possible Graph Database</title>
     <link>http://250bpm.com/blog:167</link>
     <description>Simplest Possible Graph Database</description>
+    <pubDate>Wed, 07 Oct 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Steampunk in XIX. century</title>
     <link>http://250bpm.com/blog:166</link>
     <description>Steampunk in XIX. century</description>
+    <pubDate>Sun, 30 Aug 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Split-a-Dollar Game</title>
     <link>http://250bpm.com/blog:165</link>
     <description>Split-a-Dollar Game</description>
+    <pubDate>Mon, 24 Aug 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Human Condition</title>
     <link>http://250bpm.com/blog:164</link>
     <description>The Human Condition</description>
+    <pubDate>Sun, 16 Aug 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Swiss Political System: More than You ever Wanted to Know (III.)</title>
     <link>http://250bpm.com/blog:163</link>
     <description>Swiss Political System: More than You ever Wanted to Know (III.)</description>
+    <pubDate>Mon, 10 Aug 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Swiss Political System: More than You ever Wanted to Know (II.)</title>
     <link>http://250bpm.com/blog:162</link>
     <description>Swiss Political System: More than You ever Wanted to Know (II.)</description>
+    <pubDate>Wed, 22 Jul 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Swiss Political System: More than You ever Wanted to Know (I.)</title>
     <link>http://250bpm.com/blog:161</link>
     <description>Swiss Political System: More than You ever Wanted to Know (I.)</description>
+    <pubDate>Sat, 18 Jul 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Institutional Senescence</title>
     <link>http://250bpm.com/blog:160</link>
     <description>Institutional Senescence</description>
+    <pubDate>Fri, 26 Jun 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>In Search of Slack</title>
     <link>http://250bpm.com/blog:159</link>
     <description>In Search of Slack</description>
+    <pubDate>Sat, 23 May 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Partying over Internet: Technological Aspects</title>
     <link>http://250bpm.com/blog:158</link>
     <description>Partying over Internet: Technological Aspects</description>
+    <pubDate>Sun, 05 Apr 2020 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Missing Piece</title>
     <link>http://250bpm.com/blog:157</link>
     <description>The Missing Piece</description>
+    <pubDate>Sun, 27 Oct 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Happy Petrov Day!</title>
     <link>http://250bpm.com/blog:156</link>
     <description>Happy Petrov Day!</description>
+    <pubDate>Thu, 26 Sep 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Becoming Clueless</title>
     <link>http://250bpm.com/blog:155</link>
     <description>On Becoming Clueless</description>
+    <pubDate>Tue, 24 Sep 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Type-safeness in Shell</title>
     <link>http://250bpm.com/blog:154</link>
     <description>Type-safeness in Shell</description>
+    <pubDate>Sun, 12 May 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Hull: An alternative to shell that I&#x27;ll never have time to implement</title>
     <link>http://250bpm.com/blog:153</link>
     <description>Hull: An alternative to shell that I&#x27;ll never have time to implement</description>
+    <pubDate>Sun, 28 Apr 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On the Nature of Programming Languages</title>
     <link>http://250bpm.com/blog:152</link>
     <description>On the Nature of Programming Languages</description>
+    <pubDate>Mon, 22 Apr 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Politics of Age (the Young vs. the Old)</title>
     <link>http://250bpm.com/blog:151</link>
     <description>The Politics of Age (the Young vs. the Old)</description>
+    <pubDate>Sun, 24 Mar 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Muqaata&#x27;a by Fahad Himsi (I.)</title>
     <link>http://250bpm.com/blog:150</link>
     <description>Muqaata&#x27;a by Fahad Himsi (I.)</description>
+    <pubDate>Sun, 10 Mar 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Programmatic Code Generation: Composability</title>
     <link>http://250bpm.com/blog:149</link>
     <description>Programmatic Code Generation: Composability</description>
+    <pubDate>Sat, 02 Mar 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Lydian song</title>
     <link>http://250bpm.com/blog:148</link>
     <description>Lydian song</description>
+    <pubDate>Mon, 25 Feb 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Tiles: Report on Programmatic Code Generation</title>
     <link>http://250bpm.com/blog:147</link>
     <description>Tiles: Report on Programmatic Code Generation</description>
+    <pubDate>Thu, 21 Feb 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Graceful Shutdown</title>
     <link>http://250bpm.com/blog:146</link>
     <description>Graceful Shutdown</description>
+    <pubDate>Sat, 16 Feb 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Structured Concurrency Cross-language Forum</title>
     <link>http://250bpm.com/blog:145</link>
     <description>Structured Concurrency Cross-language Forum</description>
+    <pubDate>Sun, 10 Feb 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Confessions of an Abstraction Hater</title>
     <link>http://250bpm.com/blog:144</link>
     <description>Confessions of an Abstraction Hater</description>
+    <pubDate>Sun, 27 Jan 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Announcement: A talk about structured concurrency at FOSDEM</title>
     <link>http://250bpm.com/blog:143</link>
     <description>Announcement: A talk about structured concurrency at FOSDEM</description>
+    <pubDate>Wed, 02 Jan 2019 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>State Machines and the Strange Case of Mutating API</title>
     <link>http://250bpm.com/blog:142</link>
     <description>State Machines and the Strange Case of Mutating API</description>
+    <pubDate>Mon, 24 Dec 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Equivalence of State Machines and Coroutines</title>
     <link>http://250bpm.com/blog:141</link>
     <description>Equivalence of State Machines and Coroutines</description>
+    <pubDate>Sat, 15 Dec 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Rigorous Error Handling</title>
     <link>http://250bpm.com/blog:140</link>
     <description>On Rigorous Error Handling</description>
+    <pubDate>Sat, 17 Nov 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Two Approaches to Structured Concurrency</title>
     <link>http://250bpm.com/blog:139</link>
     <description>Two Approaches to Structured Concurrency</description>
+    <pubDate>Wed, 31 Oct 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Unikernels: No Longer an Academic Exercise</title>
     <link>http://250bpm.com/blog:138</link>
     <description>Unikernels: No Longer an Academic Exercise</description>
+    <pubDate>Tue, 23 Oct 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Update on Structured Concurrency</title>
     <link>http://250bpm.com/blog:137</link>
     <description>Update on Structured Concurrency</description>
+    <pubDate>Fri, 19 Oct 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Coordination Problems in Evolution: The Rise of Eukaryotes</title>
     <link>http://250bpm.com/blog:136</link>
     <description>Coordination Problems in Evolution: The Rise of Eukaryotes</description>
+    <pubDate>Sun, 14 Oct 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Coordination Problems in Evolution: Eigen&#x27;s Paradox</title>
     <link>http://250bpm.com/blog:135</link>
     <description>Coordination Problems in Evolution: Eigen&#x27;s Paradox</description>
+    <pubDate>Fri, 12 Oct 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>One-person Universe</title>
     <link>http://250bpm.com/blog:134</link>
     <description>One-person Universe</description>
+    <pubDate>Tue, 09 Oct 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>What Can Philosophers Learn from Programmers?</title>
     <link>http://250bpm.com/blog:133</link>
     <description>What Can Philosophers Learn from Programmers?</description>
+    <pubDate>Fri, 28 Sep 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Anti-social Punishment</title>
     <link>http://250bpm.com/blog:132</link>
     <description>Anti-social Punishment</description>
+    <pubDate>Thu, 27 Sep 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Eb</title>
     <link>http://250bpm.com/blog:131</link>
     <description>The Eb</description>
+    <pubDate>Fri, 31 Aug 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Interstellar Communication</title>
     <link>http://250bpm.com/blog:130</link>
     <description>On Interstellar Communication</description>
+    <pubDate>Sat, 18 Aug 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Garden of Forking Paths</title>
     <link>http://250bpm.com/blog:129</link>
     <description>The Garden of Forking Paths</description>
+    <pubDate>Sun, 10 Jun 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Inadequate Equilibria vs. Governance of the Commons</title>
     <link>http://250bpm.com/blog:128</link>
     <description>Inadequate Equilibria vs. Governance of the Commons</description>
+    <pubDate>Fri, 25 May 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Soviet-era Jokes, Common Knowledge, Irony</title>
     <link>http://250bpm.com/blog:127</link>
     <description>Soviet-era Jokes, Common Knowledge, Irony</description>
+    <pubDate>Sat, 12 May 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Musings on Social Capital</title>
     <link>http://250bpm.com/blog:126</link>
     <description>Musings on Social Capital</description>
+    <pubDate>Thu, 03 May 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Research: Rescuers during the Holocaust</title>
     <link>http://250bpm.com/blog:125</link>
     <description>Research: Rescuers during the Holocaust</description>
+    <pubDate>Sun, 29 Apr 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Structured Concurrency in High-level Languages</title>
     <link>http://250bpm.com/blog:124</link>
     <description>Structured Concurrency in High-level Languages</description>
+    <pubDate>Sat, 28 Apr 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Progressivism vs. Conservatism: A Game-theoretic Approach</title>
     <link>http://250bpm.com/blog:123</link>
     <description>Progressivism vs. Conservatism: A Game-theoretic Approach</description>
+    <pubDate>Sat, 21 Apr 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Schooling in your Head</title>
     <link>http://250bpm.com/blog:122</link>
     <description>Schooling in your Head</description>
+    <pubDate>Mon, 02 Apr 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Composable Network Protocols vs. Encapsulation</title>
     <link>http://250bpm.com/blog:121</link>
     <description>Composable Network Protocols vs. Encapsulation</description>
+    <pubDate>Thu, 29 Mar 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Mojim Spoluobčanom (To My Compatriots)</title>
     <link>http://250bpm.com/blog:120</link>
     <description>Mojim Spoluobčanom (To My Compatriots)</description>
+    <pubDate>Thu, 22 Mar 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Documentation Driven Design</title>
     <link>http://250bpm.com/blog:119</link>
     <description>Documentation Driven Design</description>
+    <pubDate>Sun, 18 Feb 2018 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Game-theoretic Approach to Tradition</title>
     <link>http://250bpm.com/blog:118</link>
     <description>Game-theoretic Approach to Tradition</description>
+    <pubDate>Tue, 24 Jan 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Crypto for Kids: Messenger&#x27;s Story</title>
     <link>http://250bpm.com/blog:117</link>
     <description>Crypto for Kids: Messenger&#x27;s Story</description>
+    <pubDate>Thu, 28 Dec 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Your Share of National Wealth for a Microwave Oven!</title>
     <link>http://250bpm.com/blog:116</link>
     <description>Your Share of National Wealth for a Microwave Oven!</description>
+    <pubDate>Sat, 23 Dec 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Computational Complexity as a Law of Nature</title>
     <link>http://250bpm.com/blog:115</link>
     <description>Computational Complexity as a Law of Nature</description>
+    <pubDate>Thu, 07 Dec 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Inadequate Equilibria</title>
     <link>http://250bpm.com/blog:114</link>
     <description>Inadequate Equilibria</description>
+    <pubDate>Mon, 04 Dec 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Suicide by Culture</title>
     <link>http://250bpm.com/blog:113</link>
     <description>Suicide by Culture</description>
+    <pubDate>Sat, 02 Dec 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Low Hanging Fruit of Programming Language Design</title>
     <link>http://250bpm.com/blog:112</link>
     <description>Low Hanging Fruit of Programming Language Design</description>
+    <pubDate>Tue, 21 Nov 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Evolving towards Extinction</title>
     <link>http://250bpm.com/blog:111</link>
     <description>Evolving towards Extinction</description>
+    <pubDate>Fri, 03 Nov 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Hard Things in Computer Science: Naming things</title>
     <link>http://250bpm.com/blog:110</link>
     <description>Hard Things in Computer Science: Naming things</description>
+    <pubDate>Mon, 30 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>A Microstory</title>
     <link>http://250bpm.com/blog:109</link>
     <description>A Microstory</description>
+    <pubDate>Mon, 16 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Modern Propaganda</title>
     <link>http://250bpm.com/blog:108</link>
     <description>On Modern Propaganda</description>
+    <pubDate>Mon, 16 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Ontogeny Recapitulates Phylogeny</title>
     <link>http://250bpm.com/blog:107</link>
     <description>Ontogeny Recapitulates Phylogeny</description>
+    <pubDate>Sun, 15 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>A Thought on the AI Risk</title>
     <link>http://250bpm.com/blog:106</link>
     <description>A Thought on the AI Risk</description>
+    <pubDate>Sat, 14 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Intellectual Honesty</title>
     <link>http://250bpm.com/blog:105</link>
     <description>On Intellectual Honesty</description>
+    <pubDate>Mon, 09 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>A Tale of Two Countries</title>
     <link>http://250bpm.com/blog:104</link>
     <description>A Tale of Two Countries</description>
+    <pubDate>Sun, 08 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Moral Dunning-Kruger</title>
     <link>http://250bpm.com/blog:103</link>
     <description>Moral Dunning-Kruger</description>
+    <pubDate>Sat, 07 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Kaizen of Programming</title>
     <link>http://250bpm.com/blog:102</link>
     <description>Kaizen of Programming</description>
+    <pubDate>Wed, 04 Oct 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Gift vs. Reputation in OSS</title>
     <link>http://250bpm.com/blog:101</link>
     <description>Gift vs. Reputation in OSS</description>
+    <pubDate>Tue, 12 Sep 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>&quot;Being from a Worker Family&quot;</title>
     <link>http://250bpm.com/blog:100</link>
     <description>&quot;Being from a Worker Family&quot;</description>
+    <pubDate>Sun, 20 Aug 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On Tolerance</title>
     <link>http://250bpm.com/blog:99</link>
     <description>On Tolerance</description>
+    <pubDate>Thu, 17 Aug 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Infinite Mirrors and Sexual Selection</title>
     <link>http://250bpm.com/blog:98</link>
     <description>Infinite Mirrors and Sexual Selection</description>
+    <pubDate>Sun, 13 Aug 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Game with Infinite Mirrors</title>
     <link>http://250bpm.com/blog:97</link>
     <description>Game with Infinite Mirrors</description>
+    <pubDate>Sat, 12 Aug 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Reputation Engineering, part III</title>
     <link>http://250bpm.com/blog:96</link>
     <description>Reputation Engineering, part III</description>
+    <pubDate>Mon, 17 Jul 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Linguistics and Programming Languages</title>
     <link>http://250bpm.com/blog:95</link>
     <description>Linguistics and Programming Languages</description>
+    <pubDate>Thu, 01 Jun 2006 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Reputation Engineering, part II</title>
     <link>http://250bpm.com/blog:94</link>
     <description>Reputation Engineering, part II</description>
+    <pubDate>Thu, 13 Jul 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Note on Homesteading the Noosphere</title>
     <link>http://250bpm.com/blog:93</link>
     <description>Note on Homesteading the Noosphere</description>
+    <pubDate>Wed, 05 Jul 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Reputation Engineering, Part I</title>
     <link>http://250bpm.com/blog:92</link>
     <description>Reputation Engineering, Part I</description>
+    <pubDate>Sun, 02 Jul 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Sure, we have imperative and functional. But what about cartesian programming?</title>
     <link>http://250bpm.com/blog:91</link>
     <description>Sure, we have imperative and functional. But what about cartesian programming?</description>
+    <pubDate>Sun, 30 Apr 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Why is my TCP not reliable (expert edition)</title>
     <link>http://250bpm.com/blog:90</link>
     <description>Why is my TCP not reliable (expert edition)</description>
+    <pubDate>Fri, 07 Apr 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Digital encoding. Legacy software. Evolution.</title>
     <link>http://250bpm.com/blog:89</link>
     <description>Digital encoding. Legacy software. Evolution.</description>
+    <pubDate>Sat, 25 Feb 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>SRE&#x27;s review of Democracy</title>
     <link>http://250bpm.com/blog:88</link>
     <description>SRE&#x27;s review of Democracy</description>
+    <pubDate>Tue, 07 Feb 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Few thoughts on current political situation</title>
     <link>http://250bpm.com/blog:87</link>
     <description>Few thoughts on current political situation</description>
+    <pubDate>Mon, 06 Feb 2017 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Cost of Abstraction</title>
     <link>http://250bpm.com/blog:86</link>
     <description>The Cost of Abstraction</description>
+    <pubDate>Mon, 07 Nov 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Debt Cancellation Referendum</title>
     <link>http://250bpm.com/blog:85</link>
     <description>Debt Cancellation Referendum</description>
+    <pubDate>Mon, 25 Jul 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Birch</title>
     <link>http://250bpm.com/blog:84</link>
     <description>The Birch</description>
+    <pubDate>Mon, 13 Jun 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Awe of Cryptography</title>
     <link>http://250bpm.com/blog:83</link>
     <description>The Awe of Cryptography</description>
+    <pubDate>Sat, 21 May 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Software Licenses and Failed States</title>
     <link>http://250bpm.com/blog:82</link>
     <description>Software Licenses and Failed States</description>
+    <pubDate>Mon, 16 May 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Performance of green threads and why it matters</title>
     <link>http://250bpm.com/blog:81</link>
     <description>Performance of green threads and why it matters</description>
+    <pubDate>Sun, 08 May 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Nanny World</title>
     <link>http://250bpm.com/blog:80</link>
     <description>The Nanny World</description>
+    <pubDate>Sun, 01 May 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Three simple pieces for piano</title>
     <link>http://250bpm.com/blog:79</link>
     <description>Three simple pieces for piano</description>
+    <pubDate>Tue, 26 Apr 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Adventures of Boltzmann Brain (part III)</title>
     <link>http://250bpm.com/blog:78</link>
     <description>The Adventures of Boltzmann Brain (part III)</description>
+    <pubDate>Sat, 23 Apr 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Adventures of Boltzmann Brain (part II)</title>
     <link>http://250bpm.com/blog:77</link>
     <description>The Adventures of Boltzmann Brain (part II)</description>
+    <pubDate>Sun, 27 Mar 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Uncertainty principle in economics</title>
     <link>http://250bpm.com/blog:76</link>
     <description>Uncertainty principle in economics</description>
+    <pubDate>Wed, 23 Mar 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>On printing money</title>
     <link>http://250bpm.com/blog:75</link>
     <description>On printing money</description>
+    <pubDate>Mon, 21 Mar 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Adventures of Boltzmann Brain (part I)</title>
     <link>http://250bpm.com/blog:74</link>
     <description>The Adventures of Boltzmann Brain (part I)</description>
+    <pubDate>Sat, 12 Mar 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Footnotes to &quot;Select Statement Considered Harmful&quot;</title>
     <link>http://250bpm.com/blog:73</link>
     <description>Footnotes to &quot;Select Statement Considered Harmful&quot;</description>
+    <pubDate>Tue, 23 Feb 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Select Statement Considered Harmful</title>
     <link>http://250bpm.com/blog:72</link>
     <description>Select Statement Considered Harmful</description>
+    <pubDate>Sat, 20 Feb 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Structured Concurrency</title>
     <link>http://250bpm.com/blog:71</link>
     <description>Structured Concurrency</description>
+    <pubDate>Sun, 07 Feb 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Getting rid of state machines (II)</title>
     <link>http://250bpm.com/blog:70</link>
     <description>Getting rid of state machines (II)</description>
+    <pubDate>Mon, 25 Jan 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Getting rid of state machines (I)</title>
     <link>http://250bpm.com/blog:69</link>
     <description>Getting rid of state machines (I)</description>
+    <pubDate>Tue, 05 Jan 2016 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Enforced Error Handling</title>
     <link>http://250bpm.com/blog:68</link>
     <description>Enforced Error Handling</description>
+    <pubDate>Sat, 19 Dec 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Software Totemism</title>
     <link>http://250bpm.com/blog:67</link>
     <description>Software Totemism</description>
+    <pubDate>Sat, 14 Nov 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Centrifugal Governor or Why I am not a Libertarian</title>
     <link>http://250bpm.com/blog:66</link>
     <description>Centrifugal Governor or Why I am not a Libertarian</description>
+    <pubDate>Sun, 25 Oct 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Ecology of Software Quality</title>
     <link>http://250bpm.com/blog:65</link>
     <description>Ecology of Software Quality</description>
+    <pubDate>Wed, 14 Oct 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Celestial Emporium of Benevolent Knowledge</title>
     <link>http://250bpm.com/blog:64</link>
     <description>Celestial Emporium of Benevolent Knowledge</description>
+    <pubDate>Mon, 05 Oct 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Saving the journalism. With bitcoin.</title>
     <link>http://250bpm.com/blog:63</link>
     <description>Saving the journalism. With bitcoin.</description>
+    <pubDate>Tue, 15 Sep 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>A really hard problem</title>
     <link>http://250bpm.com/blog:62</link>
     <description>A really hard problem</description>
+    <pubDate>Mon, 14 Sep 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>You cannot have at-least-once broadcast</title>
     <link>http://250bpm.com/blog:61</link>
     <description>You cannot have at-least-once broadcast</description>
+    <pubDate>Sun, 06 Sep 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Be just or be data-driven?</title>
     <link>http://250bpm.com/blog:60</link>
     <description>Be just or be data-driven?</description>
+    <pubDate>Wed, 19 Aug 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>OO languages spend most effort addressing a minority use case</title>
     <link>http://250bpm.com/blog:59</link>
     <description>OO languages spend most effort addressing a minority use case</description>
+    <pubDate>Sat, 15 Aug 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Documentation at scale: The principles</title>
     <link>http://250bpm.com/blog:58</link>
     <description>Documentation at scale: The principles</description>
+    <pubDate>Sun, 09 Aug 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Document intent not algorithm: A use case</title>
     <link>http://250bpm.com/blog:57</link>
     <description>Document intent not algorithm: A use case</description>
+    <pubDate>Mon, 03 Aug 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Advanced metaprogramming in C</title>
     <link>http://250bpm.com/blog:56</link>
     <description>Advanced metaprogramming in C</description>
+    <pubDate>Sat, 01 Aug 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Let&#x27;s stop kidding ourselves about APIs</title>
     <link>http://250bpm.com/blog:55</link>
     <description>Let&#x27;s stop kidding ourselves about APIs</description>
+    <pubDate>Tue, 28 Jul 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Second Use Case for Literate Programming</title>
     <link>http://250bpm.com/blog:54</link>
     <description>The Second Use Case for Literate Programming</description>
+    <pubDate>Mon, 20 Jul 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>A case for unstructured programming</title>
     <link>http://250bpm.com/blog:53</link>
     <description>A case for unstructured programming</description>
+    <pubDate>Sat, 18 Jul 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Where are Python macros?</title>
     <link>http://250bpm.com/blog:52</link>
     <description>Where are Python macros?</description>
+    <pubDate>Sun, 05 Jul 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Dissecting Software Component&#x27;s Reproductive System</title>
     <link>http://250bpm.com/blog:51</link>
     <description>Dissecting Software Component&#x27;s Reproductive System</description>
+    <pubDate>Thu, 25 Jun 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Finish your stuff</title>
     <link>http://250bpm.com/blog:50</link>
     <description>Finish your stuff</description>
+    <pubDate>Tue, 09 Jun 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Reusability Trap</title>
     <link>http://250bpm.com/blog:49</link>
     <description>Reusability Trap</description>
+    <pubDate>Tue, 02 Jun 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Coroutines in C with Arbitrary Arguments</title>
     <link>http://250bpm.com/blog:48</link>
     <description>Coroutines in C with Arbitrary Arguments</description>
+    <pubDate>Sun, 19 Apr 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>A cryptopuzzle. Ready, steady, go!</title>
     <link>http://250bpm.com/blog:47</link>
     <description>A cryptopuzzle. Ready, steady, go!</description>
+    <pubDate>Fri, 16 Jan 2015 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Non-interactive zero knowledge proofs for fun and profit</title>
     <link>http://250bpm.com/blog:46</link>
     <description>Non-interactive zero knowledge proofs for fun and profit</description>
+    <pubDate>Sun, 07 Dec 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Clockwork inside Game of Thrones</title>
     <link>http://250bpm.com/blog:45</link>
     <description>The Clockwork inside Game of Thrones</description>
+    <pubDate>Thu, 27 Nov 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Bullshit jobs</title>
     <link>http://250bpm.com/blog:44</link>
     <description>Bullshit jobs</description>
+    <pubDate>Thu, 27 Nov 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Magic numbers in C</title>
     <link>http://250bpm.com/blog:43</link>
     <description>Magic numbers in C</description>
+    <pubDate>Thu, 27 Nov 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Are you a programmer-mathematician or a programmer-handyman?</title>
     <link>http://250bpm.com/blog:42</link>
     <description>Are you a programmer-mathematician or a programmer-handyman?</description>
+    <pubDate>Fri, 25 Jul 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Idiot&#x27;s Guide to ABI Versioning</title>
     <link>http://250bpm.com/blog:41</link>
     <description>Idiot&#x27;s Guide to ABI Versioning</description>
+    <pubDate>Tue, 10 Jun 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Unit Test Fetish</title>
     <link>http://250bpm.com/blog:40</link>
     <description>Unit Test Fetish</description>
+    <pubDate>Wed, 04 Jun 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Design of PUB/SUB subsystem in ØMQ</title>
     <link>http://250bpm.com/blog:39</link>
     <description>Design of PUB/SUB subsystem in ØMQ</description>
+    <pubDate>Sun, 04 May 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Code Generation &amp; Visual Smog in Code (part II)</title>
     <link>http://250bpm.com/blog:38</link>
     <description>Code Generation &amp; Visual Smog in Code (part II)</description>
+    <pubDate>Sun, 27 Apr 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Code Generation &amp; Visual Smog in Code (part I)</title>
     <link>http://250bpm.com/blog:37</link>
     <description>Code Generation &amp; Visual Smog in Code (part I)</description>
+    <pubDate>Mon, 21 Apr 2014 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>In the Defense of Spaghetti Code</title>
     <link>http://250bpm.com/blog:36</link>
     <description>In the Defense of Spaghetti Code</description>
+    <pubDate>Mon, 25 Mar 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Poor Man&#x27;s Scientific Method</title>
     <link>http://250bpm.com/blog:35</link>
     <description>Poor Man&#x27;s Scientific Method</description>
+    <pubDate>Tue, 31 Dec 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Second Step Towards Immortality</title>
     <link>http://250bpm.com/blog:34</link>
     <description>The Second Step Towards Immortality</description>
+    <pubDate>Fri, 27 Dec 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Bitcoins &amp; Deflation</title>
     <link>http://250bpm.com/blog:33</link>
     <description>Bitcoins &amp; Deflation</description>
+    <pubDate>Thu, 19 Dec 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Fighting Efficiency</title>
     <link>http://250bpm.com/blog:32</link>
     <description>Fighting Efficiency</description>
+    <pubDate>Sun, 15 Dec 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Pashalik Syndrome</title>
     <link>http://250bpm.com/blog:31</link>
     <description>The Pashalik Syndrome</description>
+    <pubDate>Sun, 08 Dec 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Beyond Rational Idiotism</title>
     <link>http://250bpm.com/blog:30</link>
     <description>Beyond Rational Idiotism</description>
+    <pubDate>Sun, 01 Dec 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Tragedy of the Commons and Tragedy of the Privately Owned Land</title>
     <link>http://250bpm.com/blog:29</link>
     <description>Tragedy of the Commons and Tragedy of the Privately Owned Land</description>
+    <pubDate>Fri, 29 Nov 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Public Key Encryption for Kids</title>
     <link>http://250bpm.com/blog:28</link>
     <description>Public Key Encryption for Kids</description>
+    <pubDate>Thu, 24 Oct 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Backdoors in Encryption Standards and How To Fight Them</title>
     <link>http://250bpm.com/blog:27</link>
     <description>Backdoors in Encryption Standards and How To Fight Them</description>
+    <pubDate>Wed, 11 Sep 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>nanomsg: Towards Full-Blown Configuration Management</title>
     <link>http://250bpm.com/blog:26</link>
     <description>nanomsg: Towards Full-Blown Configuration Management</description>
+    <pubDate>Tue, 10 Sep 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Event-driven architecture, state machines et al.</title>
     <link>http://250bpm.com/blog:25</link>
     <description>Event-driven architecture, state machines et al.</description>
+    <pubDate>Thu, 01 Aug 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Callback Hell</title>
     <link>http://250bpm.com/blog:24</link>
     <description>The Callback Hell</description>
+    <pubDate>Tue, 28 May 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Getting Rid of ZeroMQ-style Contexts</title>
     <link>http://250bpm.com/blog:23</link>
     <description>Getting Rid of ZeroMQ-style Contexts</description>
+    <pubDate>Tue, 14 May 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>TCP and heartbeats</title>
     <link>http://250bpm.com/blog:22</link>
     <description>TCP and heartbeats</description>
+    <pubDate>Wed, 24 Apr 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>How to Write a Language Binding for nanomsg</title>
     <link>http://250bpm.com/blog:21</link>
     <description>How to Write a Language Binding for nanomsg</description>
+    <pubDate>Thu, 28 Mar 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Using Survey Protocol for High Availability</title>
     <link>http://250bpm.com/blog:20</link>
     <description>Using Survey Protocol for High Availability</description>
+    <pubDate>Fri, 22 Mar 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Optimising Subscriptions in nanomsg</title>
     <link>http://250bpm.com/blog:19</link>
     <description>Optimising Subscriptions in nanomsg</description>
+    <pubDate>Sat, 09 Mar 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Messaging &amp; Multiplexing</title>
     <link>http://250bpm.com/blog:18</link>
     <description>Messaging &amp; Multiplexing</description>
+    <pubDate>Sun, 24 Feb 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Bus Messaging Pattern</title>
     <link>http://250bpm.com/blog:17</link>
     <description>Bus Messaging Pattern</description>
+    <pubDate>Tue, 19 Feb 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Implementing Network Protocols in User Space</title>
     <link>http://250bpm.com/blog:16</link>
     <description>Implementing Network Protocols in User Space</description>
+    <pubDate>Fri, 08 Feb 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Why Communication Infrastructure Should Use Permissive Licenses</title>
     <link>http://250bpm.com/blog:15</link>
     <description>Why Communication Infrastructure Should Use Permissive Licenses</description>
+    <pubDate>Wed, 30 Jan 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Priotitised Load Balancing with nanomsg</title>
     <link>http://250bpm.com/blog:14</link>
     <description>Priotitised Load Balancing with nanomsg</description>
+    <pubDate>Mon, 28 Jan 2013 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Location-independent Addressing with Messaging Middleware</title>
     <link>http://250bpm.com/blog:13</link>
     <description>Location-independent Addressing with Messaging Middleware</description>
+    <pubDate>Sun, 16 Dec 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>EINTR and What It Is Good For</title>
     <link>http://250bpm.com/blog:12</link>
     <description>EINTR and What It Is Good For</description>
+    <pubDate>Mon, 05 Nov 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>The Merit of AMQP (part I)</title>
     <link>http://250bpm.com/blog:11</link>
     <description>The Merit of AMQP (part I)</description>
+    <pubDate>Thu, 01 Nov 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Getting Rid of Domain Registrars Using Bitcoin Algorithm</title>
     <link>http://250bpm.com/blog:10</link>
     <description>Getting Rid of Domain Registrars Using Bitcoin Algorithm</description>
+    <pubDate>Wed, 17 Oct 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Enclave Pattern</title>
     <link>http://250bpm.com/blog:9</link>
     <description>Enclave Pattern</description>
+    <pubDate>Tue, 11 Sep 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Why should I have written ZeroMQ in C, not C++ (part II)</title>
     <link>http://250bpm.com/blog:8</link>
     <description>Why should I have written ZeroMQ in C, not C++ (part II)</description>
+    <pubDate>Thu, 30 Aug 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Does GPL hurt free software?</title>
     <link>http://250bpm.com/blog:7</link>
     <description>Does GPL hurt free software?</description>
+    <pubDate>Wed, 27 Jun 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Using likely() and unlikely()</title>
     <link>http://250bpm.com/blog:6</link>
     <description>Using likely() and unlikely()</description>
+    <pubDate>Fri, 22 Jun 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Distributed Computing: The Survey Pattern</title>
     <link>http://250bpm.com/blog:5</link>
     <description>Distributed Computing: The Survey Pattern</description>
+    <pubDate>Tue, 15 May 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Why should I have written ZeroMQ in C, not C++ (part I)</title>
     <link>http://250bpm.com/blog:4</link>
     <description>Why should I have written ZeroMQ in C, not C++ (part I)</description>
+    <pubDate>Thu, 10 May 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Silicon Valley, Hollywood and Iceland as the New Superpower</title>
     <link>http://250bpm.com/blog:3</link>
     <description>Silicon Valley, Hollywood and Iceland as the New Superpower</description>
+    <pubDate>Mon, 13 Feb 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>Economics of Messaging Software</title>
     <link>http://250bpm.com/blog:2</link>
     <description>Economics of Messaging Software</description>
+    <pubDate>Mon, 23 Jan 2012 00:00:00 GMT</pubDate>
   </item>
   <item>
     <title>ØMQ: Mission Accomplished</title>
     <link>http://250bpm.com/blog:1</link>
     <description>ØMQ: Mission Accomplished</description>
+    <pubDate>Thu, 10 Nov 2011 00:00:00 GMT</pubDate>
   </item>
 </channel>
 </rss>


### PR DESCRIPTION
👋 Hello @sustrik!

I wanted to add this to my feed reader, but the lack of pubDate meant that all posts would appear as `Just now` and were prepended to my feed. 

This PR adds a rudimentary date parsing step to `maketoc.py` which handles all of the existing dates at the bottom of the post contents and outputs them as RFC 2822. 

I'm running python 3, but I believe it is 2.7 compatible.